### PR TITLE
Fix code scanning alert no. 6: Disabling certificate validation

### DIFF
--- a/libs/plugins/scully-plugin-local-cache/src/lib/http.ts
+++ b/libs/plugins/scully-plugin-local-cache/src/lib/http.ts
@@ -25,7 +25,6 @@ export function httpJson<T>(
   // You can ignore the warning (TLS) or run scully with --no-warning
   // ****************************************************************************************`);
   //   }
-  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
   const request = isSSL ? httpsRequest : httpRequest;
   return new Promise((resolve, reject) => {
     const { pathname, hostname, port, protocol, search, hash } = new URL(url);


### PR DESCRIPTION
Fixes [https://github.com/akaday/reimagined-succotash/security/code-scanning/6](https://github.com/akaday/reimagined-succotash/security/code-scanning/6)

To fix the problem, we need to ensure that TLS certificate validation is not disabled. Instead of setting `process.env['NODE_TLS_REJECT_UNAUTHORIZED']` to '0', we should remove this line to allow the default behavior of validating certificates. This change will ensure that HTTPS requests are secure and that the server's identity is verified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
