### PR TITLE
Fix code scanning alert no. 11: Resource exhaustion

### DIFF
--- a/libs/scully/src/lib/utils/serverstuff/dataServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/dataServer.ts
@@ -19,7 +19,10 @@ export async function startDataServer(ssl: boolean) {
       const { delay }: { delay: string } = req.query;
       if (delay) {
         /** get the number to pause 0 and invalid numbers will be 100 instead */
-        const pause = parseInt(delay, 10) || 100;
+        let pause = parseInt(delay, 10) || 100;
+        if (pause > 1000) {
+          pause = 1000;
+        }
         return setTimeout(next, pause);
       }
       next();


### PR DESCRIPTION
Fixes [https://github.com/akaday/reimagined-succotash/security/code-scanning/11](https://github.com/akaday/reimagined-succotash/security/code-scanning/11)

To fix the issue, we need to add a validation step to ensure that the `pause` value derived from the `delay` parameter does not exceed a reasonable limit. This will prevent excessively long delays that could lead to resource exhaustion. We will set a maximum allowable delay of 1000 milliseconds (1 second) to mitigate this risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
