### PR TITLE
Fix code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/libs/scully/package.json
+++ b/libs/scully/package.json
@@ -37,7 +37,8 @@
     "js-yaml": "^4.1.0",
     "yamljs": "^0.3.0",
     "yargs": "^17.2.1",
-    "express-rate-limit": "^7.4.1"
+    "express-rate-limit": "^7.4.1",
+    "escape-html": "^1.0.3"
   },
   "optionalDependencies": {
     "asciidoctor.js": "^1.5.9"

--- a/libs/scully/src/lib/utils/serverstuff/dataServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/dataServer.ts
@@ -1,6 +1,7 @@
 import { logOk, yellow } from '../';
 import { posts, users } from '../../testData';
 import { readDotProperty } from '../scullydot';
+import escapeHtml from 'escape-html';
 
 const express = require('express');
 
@@ -72,7 +73,7 @@ export async function startDataServer(ssl: boolean) {
     });
     dataServer.get('/*', (req, res) => {
       res.status(404);
-      res.send(`<h1>404 - ${req.url}</h1>`);
+      res.send(`<h1>404 - ${escapeHtml(req.url)}</h1>`);
     });
     return dataServer.listen(8200, hostName, (x) => {
       logOk(`Started Test data server on "${yellow(`http://${hostName}:${8200}/`)}" `);


### PR DESCRIPTION
Fixes [https://github.com/akaday/reimagined-succotash/security/code-scanning/2](https://github.com/akaday/reimagined-succotash/security/code-scanning/2)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the `req.url` before incorporating it into the HTML response. The best way to do this is by using a well-known library for escaping HTML, such as `escape-html`. This will ensure that any potentially malicious characters in the `req.url` are properly encoded, preventing XSS attacks.

- **General fix:** Use contextual output encoding/escaping before writing user input to the response.
- **Detailed fix:** Import the `escape-html` library and use it to sanitize `req.url` before including it in the response on line 75.
- **Specific changes:** Modify the file `libs/scully/src/lib/utils/serverstuff/dataServer.ts` to include the `escape-html` library and use it to sanitize `req.url`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
