### PR TITLE
Fix code scanning alert no. 12: Prototype-polluting assignment

### DIFF
--- a/libs/scully/src/lib/pluginManagement/pluginRepository.ts
+++ b/libs/scully/src/lib/pluginManagement/pluginRepository.ts
@@ -54,6 +54,9 @@ export const registerPlugin = <T extends keyof PluginFuncs>(
   if (typeof name === 'symbol') {
     logWarn(`${displayName} is a Symbol. Using those is deprecated. use "const x = 'myId' as const" instead`);
   }
+  if (!pluginTypes.includes(type)) {
+    throw new Error(`Invalid plugin type: ${type}`);
+  }
   switch (type) {
     case 'fileHandler':
       plugin[AlternateExtensionsForFilePlugin] = Array.isArray(pluginOptions) ? pluginOptions : [];


### PR DESCRIPTION
Fixes [https://github.com/akaday/reimagined-succotash/security/code-scanning/12](https://github.com/akaday/reimagined-succotash/security/code-scanning/12)

To fix the prototype pollution vulnerability, we need to ensure that the `type` parameter cannot be set to `__proto__`, `constructor`, or `prototype`. This can be achieved by validating the `type` parameter against the predefined set of allowed values (`pluginTypes`) before using it in the `Object.assign` method.

1. Add a validation step to check if `type` is one of the allowed values in `pluginTypes`.
2. If `type` is not valid, throw an error to prevent further execution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
