### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/libs/scully/src/lib/utils/serverstuff/staticServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/staticServer.ts
@@ -132,9 +132,14 @@ function injectReloadMiddleware(req, res, next) {
     } else {
       path = join(dotProps.outDir, url);
     }
-    // console.log(path);
-    if (existFolder(path)) {
-      const content = readFileSync(path, 'utf8').toString();
+    // Normalize and validate the path
+    const normalizedPath = path.resolve(path);
+    if (!normalizedPath.startsWith(path.resolve(dotProps.outDir))) {
+      res.statusCode = 403;
+      return res.end();
+    }
+    if (existFolder(normalizedPath)) {
+      const content = readFileSync(normalizedPath, 'utf8').toString();
       try {
         const [start, endPart] = content.split('</body>');
         const injected = start + createScript() + '</body>' + endPart;


### PR DESCRIPTION
Fixes [https://github.com/akaday/reimagined-succotash/security/code-scanning/4](https://github.com/akaday/reimagined-succotash/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is validated and contained within a safe root directory. This can be achieved by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. This approach will prevent path traversal attacks by removing any `..` segments and ensuring the path is within the allowed directory.

1. Normalize the path using `path.resolve` to remove any `..` segments.
2. Check that the normalized path starts with the root directory.
3. If the path is valid, proceed with the existing functionality; otherwise, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
