### PR TITLE
Fix code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/libs/scully/src/lib/utils/serverstuff/handleUnknownRoute.ts
+++ b/libs/scully/src/lib/utils/serverstuff/handleUnknownRoute.ts
@@ -9,6 +9,7 @@ import { handle404 } from '../cli-options';
 import { logError, logWarn, yellow } from '../log';
 import { readAllDotProps } from '../scullydot';
 import { title404 } from './title404';
+import escape from 'escape-html';
 
 const scullyConfig = readAllDotProps();
 
@@ -58,7 +59,7 @@ export const handleUnknownRoute: RequestHandler = async (req, res, next) => {
     res.status(404);
     return res.send(`
         <h1>${title404}</h1>
-        <p>The url "${req.url}" is not provided in the scully.routes.json, so it can't be generated</p>
+        <p>The url "${escape(req.url)}" is not provided in the scully.routes.json, so it can't be generated</p>
         <p>If you have routes that are not known before  you might want to serve index.html instead of this response. <br> That can be done by adding the '--404=index' option to the Scully command
         <script>
           /** triggering page ready, as there is no need to wait for a timeout */


### PR DESCRIPTION
Fixes [https://github.com/akaday/reimagined-succotash/security/code-scanning/3](https://github.com/akaday/reimagined-succotash/security/code-scanning/3)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the user input before including it in the HTML response. The best way to do this is by using a well-known library for escaping HTML, such as `escape-html`. This will ensure that any potentially malicious characters in the `req.url` are properly escaped, preventing XSS attacks.

1. Import the `escape-html` library at the top of the file.
2. Use the `escape` function from the `escape-html` library to sanitize the `req.url` before including it in the HTML response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
